### PR TITLE
why pipecat devs want to capture all participants audio by default?

### DIFF
--- a/src/pipecat/transports/services/daily.py
+++ b/src/pipecat/transports/services/daily.py
@@ -1569,10 +1569,10 @@ class DailyTransport(BaseTransport):
         id = participant["id"]
         logger.info(f"Participant joined {id}")
 
-        if self._input and self._params.audio_in_enabled:
-            await self._input.capture_participant_audio(
-                id, "microphone", self._client.in_sample_rate
-            )
+        # if self._input and self._params.audio_in_enabled:
+        #     await self._input.capture_participant_audio(
+        #         id, "microphone", self._client.in_sample_rate
+        #     )
 
         if not self._other_participant_has_joined:
             self._other_participant_has_joined = True


### PR DESCRIPTION
## Problem
- As we discovered embarassingly in today's meeting, our setup wasn't working at all. This is because the audio subscription logic was drastically changed by the Pipecat team along with an introduction of 2 magic lines which messed up our audio setup.

## Background
 Last week pipecat merged https://github.com/pipecat-ai/pipecat/pull/1828 to replace virtual devices with custom tracks and added audio renderers

## Root Cause
- As part of the above mentioned PR they introduced new magic logic i.e to capture all participant's audio by default without an ability to override it or set it to something else.

## Immediate fix
- Commented out the logic which captures all participant's audio tracks on `on_participant_joined` event and in our callback  added calls to `capture_participant_audio` function to capture audio of a specific participant

agent server PR - https://github.com/photogpt/daily-dubit-agent-server/pull/81
