### PR TITLE
Make user frames system frames

### DIFF
--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -592,7 +592,7 @@ class DubitUserStartedSpeakingFrame(Frame):
     """Replacement of UserStartedSpeakingFrame which is a SystemFrame and
     gets processed before other "regular" Frames like DataFrame.
 
-    This is necessary because BetterLLMUserContextAggregator relies on ordering of
+    This is necessary because DubitLLMUserContextAggregator relies on ordering of
     UserStartedSpeakingFrame, TranscriptionFrame and UserStoppedSpeakingFrame
     """
 
@@ -604,7 +604,7 @@ class DubitUserStoppedSpeakingFrame(Frame):
     """Replacement of UserStoppedSpeakingFrame which is a SystemFrame and
     gets processed before other "regular" Frames like DataFrame.
 
-    This is necessary because BetterLLMUserContextAggregator relies on ordering of
+    This is necessary because DubitLLMUserContextAggregator relies on ordering of
     UserStartedSpeakingFrame, TranscriptionFrame and UserStoppedSpeakingFrame
     """
 

--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -569,7 +569,7 @@ class StopInterruptionFrame(SystemFrame):
 
 
 @dataclass
-class UserStartedSpeakingFrame(Frame):
+class UserStartedSpeakingFrame(SystemFrame):
     """Emitted by VAD to indicate that a user has started speaking. This can be
     used for interruptions or other times when detecting that someone is
     speaking is more important than knowing what they're saying (as you will
@@ -581,14 +581,38 @@ class UserStartedSpeakingFrame(Frame):
 
 
 @dataclass
-class UserStoppedSpeakingFrame(Frame):
+class UserStoppedSpeakingFrame(SystemFrame):
     """Emitted by the VAD to indicate that a user stopped speaking."""
 
     emulated: bool = False
 
 
 @dataclass
-class EmulateUserStartedSpeakingFrame(Frame):
+class DubitUserStartedSpeakingFrame(Frame):
+    """Replacement of UserStartedSpeakingFrame which is a SystemFrame and
+    gets processed before other "regular" Frames like DataFrame.
+
+    This is necessary because BetterLLMUserContextAggregator relies on ordering of
+    UserStartedSpeakingFrame, TranscriptionFrame and UserStoppedSpeakingFrame
+    """
+
+    emulated: bool = False
+
+
+@dataclass
+class DubitUserStoppedSpeakingFrame(Frame):
+    """Replacement of UserStoppedSpeakingFrame which is a SystemFrame and
+    gets processed before other "regular" Frames like DataFrame.
+
+    This is necessary because BetterLLMUserContextAggregator relies on ordering of
+    UserStartedSpeakingFrame, TranscriptionFrame and UserStoppedSpeakingFrame
+    """
+
+    emulated: bool = False
+
+
+@dataclass
+class EmulateUserStartedSpeakingFrame(SystemFrame):
     """Emitted by internal processors upstream to emulate VAD behavior when a
     user starts speaking.
     """
@@ -597,7 +621,7 @@ class EmulateUserStartedSpeakingFrame(Frame):
 
 
 @dataclass
-class EmulateUserStoppedSpeakingFrame(Frame):
+class EmulateUserStoppedSpeakingFrame(SystemFrame):
     """Emitted by internal processors upstream to emulate VAD behavior when a
     user stops speaking.
     """
@@ -684,7 +708,8 @@ class FunctionCallFromLLM:
 @dataclass
 class FunctionCallsStartedFrame(SystemFrame):
     """A frame signaling that one or more function call execution is going to
-    start."""
+    start.
+    """
 
     function_calls: Sequence[FunctionCallFromLLM]
 

--- a/src/pipecat/processors/aggregators/llm_response.py
+++ b/src/pipecat/processors/aggregators/llm_response.py
@@ -358,7 +358,7 @@ class LLMContextResponseAggregator(BaseLLMResponseAggregator):
         self._aggregation = ""
 
 
-class BetterLLMUserContextAggregator(LLMContextResponseAggregator):
+class DubitLLMUserContextAggregator(LLMContextResponseAggregator):
     def __init__(
         self,
         context: OpenAILLMContext,
@@ -972,7 +972,7 @@ class LLMAssistantContextAggregator(LLMContextResponseAggregator):
         asyncio.run_coroutine_threadsafe(self.wait_for_task(task), self.get_event_loop())
 
 
-class LLMUserResponseAggregator(BetterLLMUserContextAggregator):
+class LLMUserResponseAggregator(DubitLLMUserContextAggregator):
     """User response aggregator that outputs LLMMessagesFrame instead of context frames.
 
     This aggregator extends LLMUserContextAggregator but pushes LLMMessagesFrame

--- a/src/pipecat/processors/aggregators/llm_response.py
+++ b/src/pipecat/processors/aggregators/llm_response.py
@@ -974,7 +974,7 @@ class LLMAssistantContextAggregator(LLMContextResponseAggregator):
         asyncio.run_coroutine_threadsafe(self.wait_for_task(task), self.get_event_loop())
 
 
-class LLMUserResponseAggregator(DubitLLMUserContextAggregator):
+class LLMUserResponseAggregator(LLMUserContextAggregator):
     """User response aggregator that outputs LLMMessagesFrame instead of context frames.
 
     This aggregator extends LLMUserContextAggregator but pushes LLMMessagesFrame

--- a/src/pipecat/processors/aggregators/llm_response.py
+++ b/src/pipecat/processors/aggregators/llm_response.py
@@ -24,6 +24,8 @@ from pipecat.frames.frames import (
     BotStartedSpeakingFrame,
     BotStoppedSpeakingFrame,
     CancelFrame,
+    DubitUserStartedSpeakingFrame,
+    DubitUserStoppedSpeakingFrame,
     EmulateUserStartedSpeakingFrame,
     EmulateUserStoppedSpeakingFrame,
     EndFrame,
@@ -374,11 +376,11 @@ class DubitLLMUserContextAggregator(LLMContextResponseAggregator):
     async def process_frame(self, frame: Frame, direction: FrameDirection):
         await super().process_frame(frame, direction)
 
-        if isinstance(frame, UserStartedSpeakingFrame):
+        if isinstance(frame, DubitUserStartedSpeakingFrame):
             await self.push_frame(frame, direction)
         elif isinstance(frame, TranscriptionFrame):
             await self._handle_transcription(frame)
-        elif isinstance(frame, UserStoppedSpeakingFrame):
+        elif isinstance(frame, DubitUserStoppedSpeakingFrame):
             await self.push_aggregation()
             await self.push_frame(frame, direction)
         elif isinstance(frame, LLMMessagesAppendFrame):

--- a/src/pipecat/services/google/llm_openai.py
+++ b/src/pipecat/services/google/llm_openai.py
@@ -17,8 +17,8 @@ from openai import AsyncStream
 from openai.types.chat import ChatCompletionChunk
 
 from pipecat.services.llm_service import FunctionCallFromLLM
-from pipecat.utils.tracing.service_decorators import traced_llm
 from pipecat.utils.asyncio.watchdog_async_iterator import WatchdogAsyncIterator
+from pipecat.utils.tracing.service_decorators import traced_llm
 
 # Suppress gRPC fork warnings
 os.environ["GRPC_ENABLE_FORK_SUPPORT"] = "false"

--- a/src/pipecat/services/openai/llm.py
+++ b/src/pipecat/services/openai/llm.py
@@ -17,7 +17,7 @@ from pipecat.frames.frames import (
     UserImageRawFrame,
 )
 from pipecat.processors.aggregators.llm_response import (
-    BetterLLMUserContextAggregator,
+    DubitLLMUserContextAggregator,
     LLMAssistantAggregatorParams,
     LLMAssistantContextAggregator,
     LLMUserAggregatorParams,
@@ -36,10 +36,10 @@ class OpenAIContextAggregatorPair:
         _assistant: Assistant context aggregator for processing assistant messages.
     """
 
-    _user: Union["OpenAIUserContextAggregator", "PipecatOpenAIUserContextAggregator"]
+    _user: Union["OpenAIUserContextAggregator", "DubitOpenAIUserContextAggregator"]
     _assistant: "OpenAIAssistantContextAggregator"
 
-    def user(self) -> "OpenAIUserContextAggregator":
+    def user(self) -> "OpenAIUserContextAggregator|DubitOpenAIUserContextAggregator":
         """Get the user context aggregator.
 
         Returns:
@@ -86,7 +86,7 @@ class OpenAILLMService(BaseOpenAILLMService):
         *,
         user_params: LLMUserAggregatorParams = LLMUserAggregatorParams(),
         assistant_params: LLMAssistantAggregatorParams = LLMAssistantAggregatorParams(),
-        aggregator_type: str = "ours",  # or "theirs"
+        aggregator_type: str = "pipecat",  # or "dubit"
     ) -> OpenAIContextAggregatorPair:
         """Create OpenAI-specific context aggregators.
 
@@ -105,19 +105,21 @@ class OpenAILLMService(BaseOpenAILLMService):
 
         """
         context.set_llm_adapter(self.get_llm_adapter())
-        if aggregator_type == "ours":
-            user = OpenAIUserContextAggregator(context, params=user_params)
+        if aggregator_type == "dubit":
+            user = DubitOpenAIUserContextAggregator(context, params=user_params)
         else:
-            user = PipecatOpenAIUserContextAggregator(context, params=user_params)
+            user = OpenAIUserContextAggregator(context, params=user_params)
         assistant = OpenAIAssistantContextAggregator(context, params=assistant_params)
         return OpenAIContextAggregatorPair(_user=user, _assistant=assistant)
 
 
-class OpenAIUserContextAggregator(BetterLLMUserContextAggregator):
+class DubitOpenAIUserContextAggregator(DubitLLMUserContextAggregator):
+    """Just a wrapper for DubitLLMUserContextAggregator."""
+
     pass
 
 
-class PipecatOpenAIUserContextAggregator(LLMUserContextAggregator):
+class OpenAIUserContextAggregator(LLMUserContextAggregator):
     """OpenAI-specific user context aggregator.
 
     Handles aggregation of user messages for OpenAI LLM services.


### PR DESCRIPTION
For quite a long time now, `UserStarted/Stopped` Frames were `SystemFrame` in pipecat but that interfered with our logic so, we demoted these frames to `Frame` for maintaining the order in the queue. (SystemFrame(s) are not queued and just pushed directly)

This PR introduces new CustomFrames and restores `UserStarted/Stopped` as SystemFrames

Additional compatibility changes are also included.

With this PR, tests should also pass